### PR TITLE
Bugfix for 0-dimension ndarray

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -26,7 +26,9 @@ function innerFill(order, proc, body) {
       }
     }
   }
-  code.push("var " + vars.join(","))
+  if (vars.length > 0) {
+    code.push("var " + vars.join(","))
+  }  
   //Scan loop
   for(i=dimension-1; i>=0; --i) { // Start at largest stride and work your way inwards
     idx = order[i]
@@ -319,7 +321,9 @@ function generateCWiseOp(proc, typesig) {
                       .concat(proc.body.thisVars)
                       .concat(proc.post.thisVars))
   vars = vars.concat(thisVars)
-  code.push("var " + vars.join(","))
+  if (vars.length > 0) {
+    code.push("var " + vars.join(","))
+  }
   for(var i=0; i<proc.arrayArgs.length; ++i) {
     code.push("p"+i+"|=0")
   }


### PR DESCRIPTION
This bugfix is required at least personally for me to use ndarray for tensor algebra, where scalar is just a 0-dimension tensor (ndarray).

Stages to reproduce a bug:
```javascript

> const ndarray = require('ndarray')
undefined
const {add} = require('ndarray-ops')
add(ndarray([3], []), ndarray([2], []), ndarray([1], []))
// => SyntaxError: Unexpected token |=
```

This is happening because inner code generator produces something of 
```javascript

function add_cwise_loop_m0a(SS,a0,t0,p0,a1,t1,p1,a2,t2,p2){'use strict'
var //look, no vars declared
p0|=0
p1|=0
p2|=0
var  //no vars declared, too
a0[p0]=a1[p1]+a2[p2]} return add_cwise_loop_m0a
```